### PR TITLE
Remove "sdldraw" mode and add window scaling

### DIFF
--- a/doc/triplane.6
+++ b/doc/triplane.6
@@ -15,7 +15,7 @@ to the original.
 .SH "OPTIONS"
 .PP
 .IP "\fB\-fullscreen\fP"
-Start the game in fullscreen mode.
+Start the game in fullscreen mode (can also be toggled with Alt + Enter).
 .IP "\fB\-nofullscreen\fP"
 Start the game in windowed mode (this is the default).
 .IP "\fB\-nosound\fP"

--- a/doc/triplane.6
+++ b/doc/triplane.6
@@ -25,8 +25,7 @@ time you start triplane.  To enable sounds set Physical
 Examination->Hearing->Sounds on in the game menus.
 .IP "\fB\-1, -2, -3, -4\fP"
 Scale the 320x200-pixel game window 1x, 2x, 3x or 4x using software
-scaling.  This helps you play Triplane on displays that cannot switch to
-such low resolutions.
+scaling.
 .IP "\fB\-2svga\fP"
 Scale the 800x600-pixel window 2x using software scaling, to
 produce a 1600x1200-pixel window.  This resolution is used only in

--- a/doc/triplane.6
+++ b/doc/triplane.6
@@ -15,16 +15,16 @@ to the original.
 .SH "OPTIONS"
 .PP
 .IP "\fB\-fullscreen\fP"
-Start the game in fullscreen mode (this is the default).
+Start the game in fullscreen mode.
 .IP "\fB\-nofullscreen\fP"
-Start the game in windowed mode.
+Start the game in windowed mode (this is the default).
 .IP "\fB\-nosound\fP"
 Start the game without sounds.  Note: This option also disables sounds
 in the configuration file so sounds will be disabled also the next
 time you start triplane.  To enable sounds set Physical
 Examination->Hearing->Sounds on in the game menus.
-.IP "\fB\-2, -3, -4\fP"
-Scale the 320x200-pixel game window 2x, 3x or 4x using software
+.IP "\fB\-1, -2, -3, -4\fP"
+Scale the 320x200-pixel game window 1x, 2x, 3x or 4x using software
 scaling.  This helps you play Triplane on displays that cannot switch to
 such low resolutions.
 .IP "\fB\-2svga\fP"

--- a/src/gfx/bitmap.h
+++ b/src/gfx/bitmap.h
@@ -31,7 +31,6 @@ class Bitmap {
     int16_t width, height;
     int external_image_data;    // boolean: is image_data owned by this instance
     int hastransparency;
-    SDL_Surface *sdlsurface;
 
   public:
       Bitmap(const char *image_name, int transparent = 1);
@@ -44,10 +43,8 @@ class Bitmap {
     void blit_fullscreen(void);
     void blit_to_bitmap(Bitmap * to, int xx, int yy);
     unsigned char *info(int *width = NULL, int *height = NULL);
-    void refresh_sdlsurface();
 };
 
-void all_bitmaps_refresh(void);
 Bitmap *rotate_bitmap(Bitmap * picture, int degrees);
 int bitmap_exists(const char *name);
 

--- a/src/gfx/fades.cpp
+++ b/src/gfx/fades.cpp
@@ -94,8 +94,6 @@ void partial_fade(void) {
     int hit_value, temp_hit_value;
     int c, c2, c3, temp;
 
-    assert(update_vircr_mode);
-
     next_color[0] = 0;
 
     for (c = 1; c < 256; c++) {

--- a/src/gfx/gfx.cpp
+++ b/src/gfx/gfx.cpp
@@ -36,16 +36,11 @@ void putpix(int x, int y, unsigned char c, int x1, int y1, int x2, int y2) {
         return;
     if (y > y2)
         return;
-    if (update_vircr_mode) {
-        if (current_mode == VGA_MODE) {
-            vircr[x + (y << 8) + (y << 6)] = c;
-        } else {
-            vircr[x + y * 800] = c;
-        }
+    if (current_mode == VGA_MODE) {
+        vircr[x + (y << 8) + (y << 6)] = c;
+    } else {
+        vircr[x + y * 800] = c;
     }
-
-    if (!draw_with_vircr_mode)
-        fillrect(x, y, 1, 1, c);
 }
 
 void draw_line(int x1, int y1, int x2, int y2, unsigned char vari) {
@@ -80,13 +75,8 @@ void boxi(int x1, int y1, int x2, int y2, unsigned char vari) {
 void fill_vircr(int x1, int y1, int x2, int y2, unsigned char vari) {
     int lasky;
 
-    if (update_vircr_mode) {
-        for (lasky = y1; lasky <= y2; lasky++)
-            memset(&vircr[x1 + lasky * 320], vari, x2 - x1 + 1);
-    }
-
-    if (!draw_with_vircr_mode)
-        fillrect(x1, y1, x2 - x1 + 1, y2 - y1 + 1, vari);
+    for (lasky = y1; lasky <= y2; lasky++)
+        memset(&vircr[x1 + lasky * 320], vari, x2 - x1 + 1);
 }
 
 void tyhjaa_vircr(void) {

--- a/src/io/mouse.cpp
+++ b/src/io/mouse.cpp
@@ -30,7 +30,7 @@
 #include <SDL.h>
 
 void hiiri_to(int x, int y) {
-    SDL_WarpMouseInWindow(video_state.window, x * pixel_multiplier, y * pixel_multiplier);
+    SDL_WarpMouseInWindow(video_state.window, x, y);
 }
 
 void koords(int *x, int *y, int *n1, int *n2) {
@@ -40,7 +40,4 @@ void koords(int *x, int *y, int *n1, int *n2) {
     ret = SDL_GetMouseState(x, y);
     *n1 = !!(ret & SDL_BUTTON(1));
     *n2 = !!(ret & SDL_BUTTON(3));
-
-    *x /= pixel_multiplier;
-    *y /= pixel_multiplier;
 }

--- a/src/io/video.h
+++ b/src/io/video.h
@@ -41,7 +41,6 @@ struct video_state_t {
     SDL_Renderer *renderer;
     SDL_Window *window;
     int init_done;
-    int haverealpalette;
 };
 extern struct video_state_t video_state;
 extern SDL_Color curpal[256];
@@ -59,10 +58,7 @@ void deinit_video(void);
 extern unsigned char *vircr;
 extern Bitmap *standard_background;
 extern int current_mode;
-extern int pixel_multiplier;
-extern int update_vircr_mode;
-extern int draw_with_vircr_mode;
-extern int pixel_multiplier_vga, pixel_multiplier_svga;
+extern unsigned int window_multiplier_vga, window_multiplier_svga;
 extern int wantfullscreen;
 
 #endif

--- a/src/triplane.cpp
+++ b/src/triplane.cpp
@@ -1655,9 +1655,6 @@ void main_engine(void) {
     //// Record
     setwrandom(7);
 
-    if (!draw_with_vircr_mode)
-        update_vircr_mode = 0;
-
     while (flag) {
         update_key_state();
 
@@ -1862,9 +1859,6 @@ void main_engine(void) {
             mission_duration++;
         }
     }
-
-    if (!draw_with_vircr_mode)
-        update_vircr_mode = 1;
 
     wait_relase();
     mission_re_fly = -1;
@@ -3558,20 +3552,24 @@ void handle_parameters(void) {
         loading_text("Sounds disabled.");
     }
 
+    if (findparameter("-1")) {
+        window_multiplier_vga = 1;
+    }
+
     if (findparameter("-2")) {
-        pixel_multiplier_vga = 2;
+        window_multiplier_vga = 2;
     }
 
     if (findparameter("-3")) {
-        pixel_multiplier_vga = 3;
+        window_multiplier_vga = 3;
     }
 
     if (findparameter("-4")) {
-        pixel_multiplier_vga = 4;
+        window_multiplier_vga = 4;
     }
 
     if (findparameter("-2svga")) {
-        pixel_multiplier_svga = 2;
+        window_multiplier_svga = 2;
     }
 
     if (findparameter("-fullscreen")) {
@@ -3580,10 +3578,6 @@ void handle_parameters(void) {
 
     if (findparameter("-nofullscreen")) {
         wantfullscreen = 0;
-    }
-
-    if (findparameter("-sdldraw")) {
-        draw_with_vircr_mode = 0;
     }
 }
 
@@ -3605,12 +3599,12 @@ int main(int argc, char *argv[]) {
         printf("This program is free software; you may redistribute it under the terms of\n");
         printf("the GNU General Public License version 3 or (at your option) a later version.\n");
         printf("This program has absolutely no warranty.\n\n");
-        printf("-help         Help on options\n");
-        printf("-fullscreen   Start game in fullscreen mode\n");
-        printf("-nofullscreen Start game in windowed mode (default)\n");
-        printf("-nosound      Start game without sounds\n");
-        //printf("-2, -3, -4    Zoom the 320x200-pixel game window 2x, 3x or 4x\n"); SP-TODO: Not supported
-        //printf("-2svga        Zoom the 800x600-pixel window 2x to produce 1600x1200-pixel window\n"); SP-TODO: Not supported
+        printf("-help           Help on options\n");
+        printf("-fullscreen     Start game in fullscreen mode\n");
+        printf("-nofullscreen   Start game in windowed mode (default)\n");
+        printf("-nosound        Start game without sounds\n");
+        printf("-1, -2, -3, -4  Zoom the 320x200-pixel game window 1x, 2x (default), 3x or 4x\n");
+        printf("-2svga          Zoom the 800x600-pixel window 2x to produce 1600x1200-pixel window\n");
         printf("\n");
         exit(0);
     }
@@ -3635,7 +3629,6 @@ int main(int argc, char *argv[]) {
     handle_parameters();
 
     /* needed to find joysticks */
-    /* needs draw_with_vircr_mode parameter from handle_parameters() */
     init_video();
 
     loading_text("Looking for joystick");


### PR DESCRIPTION
Remove non-working "sdldraw" mode. Add window scaling without pixel manipulation by using SDL's window size parameters. Set default VGA scaling to 2x because 1x is very small.