### PR TITLE
Emscripten build support for browsers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,22 +13,35 @@ if(NOT DEFINED TRIPLANE_DATA)
     set(TRIPLANE_DATA ".")
 endif()
 
-# Dependencies
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2.cmake")
-    file(DOWNLOAD "https://github.com/tcbrindle/sdl2-cmake-scripts/raw/master/FindSDL2.cmake"
-        "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2.cmake")
-endif()
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2_mixer.cmake")
-    file(DOWNLOAD "https://github.com/tcbrindle/sdl2-cmake-scripts/raw/master/FindSDL2_mixer.cmake"
-        "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2_mixer.cmake")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
+    set(EMCC 1)
 endif()
 
-find_package(SDL2 REQUIRED)
-find_package(SDL2_mixer REQUIRED)
+# Dependencies
+if (NOT EMCC)
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2.cmake")
+        file(DOWNLOAD "https://github.com/tcbrindle/sdl2-cmake-scripts/raw/master/FindSDL2.cmake"
+            "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2.cmake")
+    endif()
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2_mixer.cmake")
+        file(DOWNLOAD "https://github.com/tcbrindle/sdl2-cmake-scripts/raw/master/FindSDL2_mixer.cmake"
+            "${CMAKE_BINARY_DIR}/cmake-modules/FindSDL2_mixer.cmake")
+    endif()
+
+    find_package(SDL2 REQUIRED)
+    find_package(SDL2_mixer REQUIRED)
+endif()
 
 # Compiler flags
 if (MSVC)
     add_compile_options(/MP /MT /WX /wd4996)
+elseif (EMCC)
+    # fokker.dks must be separately built or borrowed from elsewhere for EMCC builds - see README!
+    set(USE_FLAGS "-O3 -s ASYNCIFY -s USE_SDL=2 -s -s USE_SDL_MIXER=2 -s TOTAL_MEMORY=32MB --preload-file fokker.dks --shell-file ${CMAKE_SOURCE_DIR}/src/web/shell.html")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${USE_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${USE_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${USE_FLAGS}")
+    set(CMAKE_EXECUTABLE_SUFFIX .html)
 else()
     # Warnings to be fixed
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
@@ -38,8 +51,13 @@ endif()
 set(COMMON_DEFINITIONS
     TRIPLANE_DATA=\"${TRIPLANE_DATA}\"
     TRIPLANE_VERSION=\"${PROJECT_VERSION}\"
-    TRIPLANE_SP_VERSION=\"${TRIPLANE_SP_VERSION}\"
-    HAVE_SDL_MIXER=1)
+    TRIPLANE_SP_VERSION=\"${TRIPLANE_SP_VERSION}\")
+
+if (NOT EMCC)
+    # EMCC's Mixer does not support used sound format, disable for now
+    set(COMMON_DEFINITIONS
+        HAVE_SDL_MIXER=1)
+endif()
 
 # Common library
 add_library(common STATIC
@@ -72,28 +90,34 @@ endif()
 target_compile_definitions(common PRIVATE
     ${COMMON_DEFINITIONS})
 
+if (NOT EMCC)
+    target_include_directories(common SYSTEM PUBLIC
+        ${SDL2_MIXER_INCLUDE_DIR}
+        ${SDL2_INCLUDE_DIR})
+
+    target_link_libraries(common
+        ${SDL2_LIBRARY}
+        ${SDL2_MIXER_LIBRARIES})
+endif()
+
 target_include_directories(common SYSTEM PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${SDL2_MIXER_INCLUDE_DIR}
-    ${SDL2_INCLUDE_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(common
-    ${SDL2_LIBRARY}
-    ${SDL2_MIXER_LIBRARIES})
+if (NOT EMCC)
+    # DKS data packet creation tool
+    add_executable(dksbuild
+        src/tools/dksbuild/dksbuild.cc)
 
-# DKS data packet creation tool
-add_executable(dksbuild
-    src/tools/dksbuild/dksbuild.cc)
+    # DKS data packet
+    add_custom_command(OUTPUT fokker.dks
+        COMMAND dksbuild ${CMAKE_CURRENT_LIST_DIR}/data/fokker.lst
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/fokker.dks ${CMAKE_BINARY_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        DEPENDS dksbuild)
 
-# DKS data packet
-add_custom_command(OUTPUT fokker.dks
-    COMMAND dksbuild ${CMAKE_CURRENT_LIST_DIR}/data/fokker.lst
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/fokker.dks ${CMAKE_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    DEPENDS dksbuild)
-
-add_custom_target(generate-dks
-    DEPENDS fokker.dks)
+    add_custom_target(generate-dks
+        DEPENDS fokker.dks)
+endif()
 
 # Triplane executable
 add_executable(${PROJECT_NAME}
@@ -134,7 +158,9 @@ target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
 target_link_libraries(${PROJECT_NAME}
     common)
 
-add_dependencies(${PROJECT_NAME} generate-dks)
+if (NOT EMCC)
+    add_dependencies(${PROJECT_NAME} generate-dks)
+endif()
 
 if (MSVC)
     target_link_libraries(${PROJECT_NAME} winmm.lib)
@@ -142,24 +168,26 @@ else()
     target_link_libraries(${PROJECT_NAME} m)
 endif()
 
-# Level editor
-add_executable(lvledit
-    src/tools/lvledit/lvledit.cpp)
+if (NOT EMCC)
+    # Level editor
+    add_executable(lvledit
+        src/tools/lvledit/lvledit.cpp)
 
-target_link_libraries(lvledit
-    common
-    ${SDL2_LIBRARY})
+    target_link_libraries(lvledit
+        common
+        ${SDL2_LIBRARY})
 
-target_include_directories(lvledit SYSTEM PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${SDL2_INCLUDE_DIR})
+    target_include_directories(lvledit SYSTEM PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${SDL2_INCLUDE_DIR})
 
-# Image tools
-add_executable(pgdview
-    src/tools/pgdview/pgdview.cpp)
+    # Image tools
+    add_executable(pgdview
+        src/tools/pgdview/pgdview.cpp)
 
-target_link_libraries(pgdview
-    common)
+    target_link_libraries(pgdview
+        common)
 
-add_executable(pcx2pgd
-    src/tools/pcx2pgd/pcx2pgd.cpp)
+    add_executable(pcx2pgd
+        src/tools/pcx2pgd/pcx2pgd.cpp)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(COMMON_DEFINITIONS
 
 if (NOT EMCC)
     # EMCC's Mixer does not support used sound format, disable for now
-    set(COMMON_DEFINITIONS
+    list(APPEND COMMON_DEFINITIONS
         HAVE_SDL_MIXER=1)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ cmake -DSDL2_PATH="C:\\<path>\\SDL2-2.0.9" -DSDL2_MIXER_PATH="C:\\<path>\\SDL2_m
 ```
 which produces project files for 32-bit target. For 64-bit target, use e.g. `cmake -G "Visual Studio 15 2017 Win64"`.
 
+#### Browser build
+
+Emscripten JavaScript/WebAssembly build for browsers is also
+supported. It has limitations like missing sound and persistent data
+storing, and the port is considered as beta. You can try it live
+[here](https://suomipelit.github.io/triplane-web/).
+
+`fokker.dks` main data file must be built separately or borrowed from
+release package. Paste it to binary directory before progressing
+further.
+
+``` shell
+cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=<path to>/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake ..
+cmake --build .
+```
+
+For best performance it is recommended to build with
+`-DCMAKE_BUILD_TYPE=Release`.
+
+It might be easiest to run local HTTP server with Python
+
+``` shell
+python -m http.server
+```
+
+and opening the game with supported browser at `http://localhost:8000/triplane.html`.
+
 ## Releases
 
 ### v1.0.8-SP1 - 2019-12-14

--- a/src/io/sdl_compat.cpp
+++ b/src/io/sdl_compat.cpp
@@ -115,7 +115,7 @@ int getch(void) {
                 return s;
             }
         }
-        SDL_Delay(1);
+        nopeuskontrolli();
     }
 }
 

--- a/src/io/sdl_compat.cpp
+++ b/src/io/sdl_compat.cpp
@@ -115,6 +115,7 @@ int getch(void) {
                 return s;
             }
         }
+        SDL_Delay(1);
     }
 }
 

--- a/src/menus/tripmenu.cpp
+++ b/src/menus/tripmenu.cpp
@@ -1194,7 +1194,7 @@ void options_menu(void) {
         frost->printf(73, 43, "%s", selitykset[optimode]);
 
         switch (optimode) {
-        case 0:
+        case 0: {
             frost->printf(73, 60, "Shots visible?");
             frost->printf(73, 70, "AAA shots visible?");
             frost->printf(73, 80, "AA-MG shots visible?");
@@ -1202,14 +1202,24 @@ void options_menu(void) {
             frost->printf(73, 100, "Structure flames?");
             frost->printf(73, 110, "Use 800x600 window\nin multiplayergame?");
             frost->printf(73, 130, "Structure smoke?");
+#if !defined (__EMSCRIPTEN__)
             frost->printf(73, 140, "Fullscreen?");
+#endif
 
             for (l = 0; l < 6; l++) {
                 boxi(214, 60 + l * 10, 221, 68 + l * 10, 0);
                 boxi(224, 60 + l * 10, 231, 68 + l * 10, 0);
             }
 
-            for (l = 0; l < 2; l++) {
+            const size_t boxes =
+#if !defined (__EMSCRIPTEN__)
+              2
+#else
+              1
+#endif
+              ;
+
+            for (l = 0; l < boxes; l++) {
                 boxi(214, 130 + l * 10, 221, 138 + l * 10, 0);
                 boxi(224, 130 + l * 10, 231, 138 + l * 10, 0);
             }
@@ -1249,13 +1259,15 @@ void options_menu(void) {
             else
                 wrong->blit(225, 110);
 
+#if !defined (__EMSCRIPTEN__)
             if (config.fullscreen)
                 right->blit(215, 140);
             else
                 wrong->blit(225, 140);
+#endif
 
             break;
-
+        }
         case 1:
 
             frost->printf(73, 60, "Sounds on?");
@@ -1511,10 +1523,12 @@ void options_menu(void) {
 
                 }
 
+#if !defined (__EMSCRIPTEN__)
                 if (y >= 140 && y <= 148) {
                     // fullscreen
                     menuselect = 35;
                 }
+#endif
             }
 
         if (optimode == 1)

--- a/src/triplane.cpp
+++ b/src/triplane.cpp
@@ -650,8 +650,10 @@ int small_warning(const char *message) {
         }
     }
 
-    while (n1 || n2)
+    while (n1 || n2) {
         koords(&x, &y, &n1, &n2);
+        nopeuskontrolli();
+    }
 
     delete warnkuva;
 

--- a/src/web/shell.html
+++ b/src/web/shell.html
@@ -1,0 +1,194 @@
+<!-- Modified version of https://github.com/emscripten-core/emscripten/blob/master/src/shell.html -->
+
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      body {
+        font-family: arial;
+        margin: 0;
+        padding: none;
+        background-color: black;
+      }
+
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+      div.emscripten { text-align: center; }      
+      div.emscripten_border { border: 1px solid black; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; background-color: black; }
+
+      .spinner {
+        height: 30px;
+        width: 30px;
+        margin: 0;
+        margin-top: 20px;
+        margin-left: 20px;
+        display: inline-block;
+        vertical-align: top;
+
+        -webkit-animation: rotation .8s linear infinite;
+        -moz-animation: rotation .8s linear infinite;
+        -o-animation: rotation .8s linear infinite;
+        animation: rotation 0.8s linear infinite;
+
+        border-left: 5px solid rgb(235, 235, 235);
+        border-right: 5px solid rgb(235, 235, 235);
+        border-bottom: 5px solid rgb(235, 235, 235);
+        border-top: 5px solid rgb(120, 120, 120);
+        
+        border-radius: 100%;
+        background-color: rgb(189, 215, 46);
+      }
+
+      @-webkit-keyframes rotation {
+        from {-webkit-transform: rotate(0deg);}
+        to {-webkit-transform: rotate(360deg);}
+      }
+      @-moz-keyframes rotation {
+        from {-moz-transform: rotate(0deg);}
+        to {-moz-transform: rotate(360deg);}
+      }
+      @-o-keyframes rotation {
+        from {-o-transform: rotate(0deg);}
+        to {-o-transform: rotate(360deg);}
+      }
+      @keyframes rotation {
+        from {transform: rotate(0deg);}
+        to {transform: rotate(360deg);}
+      }
+
+      #status {
+        display: inline-block;
+        vertical-align: top;
+        margin-top: 30px;
+        margin-left: 20px;
+        font-weight: bold;
+        color: rgb(120, 120, 120);
+      }
+
+      #progress {
+        height: 20px;
+        width: 300px;
+      }
+
+      #controls {
+        display: inline-block;
+        float: right;
+        vertical-align: top;
+        margin-top: 30px;
+        margin-right: 20px;
+      }
+
+      #output {
+        width: 100%;
+        height: 200px;
+        margin: 0 auto;
+        margin-top: 10px;
+        border-left: 0px;
+        border-right: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        display: block;
+        background-color: black;
+        color: white;
+        font-family: 'Lucida Console', Monaco, monospace;
+        outline: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spinner" id='spinner'></div>
+    <div class="emscripten" id="status">Downloading...</div>
+
+    <div class="emscripten">
+      <progress value="0" max="100" id="progress" hidden=1></progress>
+    </div>
+    
+    <div class="emscripten_border">
+      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+    </div>
+    <textarea id="output" rows="8"></textarea>
+
+    <script type='text/javascript'>
+      var statusElement = document.getElementById('status');
+      var progressElement = document.getElementById('progress');
+      var spinnerElement = document.getElementById('spinner');
+
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          var element = document.getElementById('output');
+          if (element) element.value = ''; // clear browser cache
+          return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+          };
+        })(),
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          console.error(text);
+        },
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+        setStatus: function(text) {
+          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+          if (text === Module.setStatus.last.text) return;
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var now = Date.now();
+          if (m && now - Module.setStatus.last.time < 30) return; // if this is a progress update, skip it if too soon
+          Module.setStatus.last.time = now;
+          Module.setStatus.last.text = text;
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.style.display = 'none';
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+      window.onerror = function(event) {
+        // TODO: do not warn on ok events like simulating an infinite loop or exitStatus
+        Module.setStatus('Exception thrown, see JavaScript console');
+        spinnerElement.style.display = 'none';
+        Module.setStatus = function(text) {
+          if (text) Module.printErr('[post-exception status] ' + text);
+        };
+      };
+    </script>
+    {{{ SCRIPT }}}
+  </body>
+</html>


### PR DESCRIPTION
Emscripten build support for browsers. Hosted using GitHub Pages [here](https://github.com/suomipelit/triplane-web), live at https://suomipelit.github.io/triplane-web/.

- CMake changes
   - Flag external SDL dependency since it's built-in into EMCC
   - Disable Mixer for now as it's EMCC's version is not compatible with the used sound format...
   - Flag out all tools
       - `fokker.dks` main data file must be built or copied from release package separately
- Hide Fullscreen option from UI since it doesn't work in browser
- Fix few hangs due to loops without SDL_Delay which is needed to give control back to browser every now and then