### PR TITLE
Mouse position conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(triplane VERSION 1.0.8)
-set(TRIPLANE_SP_VERSION "SP1")
+set(TRIPLANE_SP_VERSION "SP2-SNAPSHOT")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/cmake-modules)

--- a/src/io/mouse.cpp
+++ b/src/io/mouse.cpp
@@ -29,6 +29,9 @@
 #include "io/video.h"
 #include <SDL.h>
 
+extern int current_mode;
+extern unsigned int window_multiplier_vga, window_multiplier_svga;
+
 void hiiri_to(int x, int y) {
     SDL_WarpMouseInWindow(video_state.window, x, y);
 }
@@ -54,6 +57,11 @@ void koords(int *x, int *y, int *n1, int *n2) {
 
     SDL_PumpEvents();
     ret = SDL_GetMouseState(x, y);
+
+    const unsigned int multiplier =
+        (current_mode == SVGA_MODE) ? window_multiplier_svga : window_multiplier_vga;
+    *x /= multiplier;
+    *y /= multiplier;
 
     if (wantfullscreen && !ret) limit(x, y);
 


### PR DESCRIPTION
Fix #9 

Mouse position did not consider window scaling. It causes a jump to the cursor when moving it between Triplane window and outside of it.

Bump version number to `SP2-SNAPSHOT` as the change is to port behavior.